### PR TITLE
fixed crash when trying to ascertain latest bix package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.3] - 2024-04-08
+
+- Fixed crash when trying to resolve latest local BepInEx package; and the package doesn't respect semantic versioning.
+
 ## [0.2.2] - 2023-12-04
 
 - Fixed download issues caused by BIX package resolution applying the new archive format to 5.X.X versions of BepInEx

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modtype-bepinex",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Adds several BepInEx specific modTypes and the ability to automatically download and install the library.",
   "main": "./out/index.js",
   "repository": "",

--- a/src/bepInExDownloader.ts
+++ b/src/bepInExDownloader.ts
@@ -126,8 +126,15 @@ export async function ensureBepInExPack(api: types.IExtensionApi,
     }
   } else if (gameConf.forceGithubDownload === true && isUpdate) {
     const latest = injectorModIds.reduce((prev, iter) => {
-      if (semver.gt(mods[iter]?.attributes?.version ?? '0.0.0', prev)) {
-        prev = mods[iter]?.attributes?.version;
+      let version: string = mods[iter]?.attributes?.version ?? '0.0.0';
+      try {
+        const coerced = semver.coerce(mods[iter]?.attributes?.version);
+        version = coerced.raw || '0.0.0';
+      } catch (err) {
+        version = '0.0.0';
+      }
+      if (semver.gt(version, prev)) {
+        prev = version;
       }
       return prev;
     }, '0.0.0');


### PR DESCRIPTION
It is possible to install a bix package manually, and change the version number to a non-semantic version.

This commit will attempt to coerce the non-semantic version or use 0.0.0

fixes nexus-mods/vortex#15446