### PR TITLE
Fix mod download loop when using customPackDownloader

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ async function onCheckModVersion(api: types.IExtensionApi,
       }
     } else if ((res as INexusDownloadInfo) !== undefined) {
       const nexDownload = res as INexusDownloadInfo;
-      if (nexDownload.fileId !== injectorMod.attributes?.fileId) {
+      if (nexDownload.fileId !== injectorMod.attributes?.fileId?.toString()) {
         return forceUpdate(nexDownload);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,14 @@ function init(context: types.IExtensionContext) {
       if (mod?.type !== MODTYPE_BIX_INJECTOR) {
         return;
       }
+      if (mod.attributes != undefined &&
+        mod.attributes.modId &&
+        mod.attributes.fileId &&
+        mod.attributes.version
+      ) {
+        // Mod already has attributes set
+        return;
+      }
       const metaDataDetails: types.ILookupDetails = {
         gameId: 'site',
         fileName: mod.attributes?.fileName,


### PR DESCRIPTION
When downloading BepInEx from a custom path - (for example https://github.com/jonanoj/TGFoAVortexExtension/blob/main/src/consts.ts#L37)
The path is successfully resolved to - https://www.nexusmods.com/taintedgrailthefallofavalon/mods/50

BUT, the lookupModMeta callback (that happens right after the modified code) doesn't correctly filter for the metadata for the specific game

This is because the file shares a hash with other games that mirrored the latest BepInEx version on nexusmods
<img width="720" height="437" alt="C2C8vTU" src="https://github.com/user-attachments/assets/79856199-0b46-4074-b62c-3dc6b5f2b3e4" />

Vortex seems to detect this mod as this one https://www.nexusmods.com/mytimeatsandrock/mods/129
And causes Vortex to set the mod's attribute to modId 129 (but on the original game ID, so https://www.nexusmods.com/taintedgrailthefallofavalon/mods/129 in my case)

This causes any "Check for updates" attempts to fail due to 404 not found error (correct game ID, wrong mod ID) 
When I manually set the game/mod/file IDs through this menu, Vortex entered a weird state and force disabled the mod every time I pressed "Check for updates"
<img width="420" height="363" alt="LZAJakE" src="https://github.com/user-attachments/assets/1369c7c4-7d0c-4fda-aa7b-0378df4307db" />


Also the forceUpdate check seems to be comparing a string with int, according to the TypeScript deifintions, the fileId should be a string, so I've added a toString() on the attributes.fileId (which is any) just in case
<img width="178" height="101" alt="image" src="https://github.com/user-attachments/assets/e7f01389-1bb8-49fe-bbb0-c52d72737c52" />
<img width="622" height="311" alt="image" src="https://github.com/user-attachments/assets/8f334705-72a0-4879-b210-85f34413c099" />
<img width="330" height="290" alt="image" src="https://github.com/user-attachments/assets/f75a794c-079a-4a06-9f41-8a8ef7865ec8" />

